### PR TITLE
Crontab installation failure - fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git submodule add https://github.com/fundor333/crontab-dotbot.git
 2. Modify your `install` script to enable the `crontab-dotbot` plugin.
 
 ```bash
-"${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" --plugin-dir crontab-dotbot-c "${CONFIG}" "${@}"
+"${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" --plugin-dir crontab-dotbot -c "${CONFIG}" "${@}"
 ```
 
 ## Usage

--- a/crontab.py
+++ b/crontab.py
@@ -41,7 +41,7 @@ class Crontab(dotbot.Plugin):
         self._delete_line(self._temp_file)
         with open(self._temp_file, "a") as file_object:
             for row in rows:
-                file_object.write("{}".format(row))
+                file_object.write("{}\n".format(row))
         subprocess.call(["crontab", "-r"])
         subprocess.call(["crontab", self._temp_file])
         os.remove(self._temp_file)

--- a/crontab.py
+++ b/crontab.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from shutil import copyfile
 
 import dotbot
 
@@ -34,8 +35,10 @@ class Crontab(dotbot.Plugin):
 
     def _read_cron_file(self, rows):
         try:
+            backup_file = self._temp_file + '.bak2'
             with open(self._temp_file, 'w+') as fout:
                 out = subprocess.call(["crontab", '-l'], stdout=fout)
+            copyfile(self._temp_file,backup_file)
         except Exception as e:
             self._log.error(e)
         self._delete_line(self._temp_file)
@@ -43,7 +46,11 @@ class Crontab(dotbot.Plugin):
             for row in rows:
                 file_object.write("{}\n".format(row))
         subprocess.call(["crontab", "-r"])
-        subprocess.call(["crontab", self._temp_file])
+        exit_code = subprocess.call(["crontab", self._temp_file])
+        if exit_code != 0:
+            exit_code = subprocess.call(["crontab", backup_file])
+        if exit_code == 0:
+            os.remove(backup_file)
         os.remove(self._temp_file)
 
     def _delete_line(self, original_file):


### PR DESCRIPTION
Hi,

When line 46 in crontab.py is executed:
`         subprocess.call(["crontab", self._temp_file])`

I get the following error, depending on the OS & cron version, python3 in both cases:

CentOS6
```
"out.txt":1: premature EOF
errors in crontab file, can't install
```

WSL, Ubuntu 20
`new crontab file is missing newline before EOF, can't install.`

The side effect is that no crontab is installed after this error, even the old one is lost.

install.conf.yaml excerpt:
```
- crontab:
  - cron: 54 * * * *
    command: touch $HOME/file1.txt
  - cron: 55 * * * *
    command: touch $HOME/file2.txt
```
out.txt content as created by _read_cron_file method (no newline characters):
`54 * * * * touch $HOME/file1.txt #dotbot-crontab55 * * * * touch $HOME/file2.txt #dotbot-crontab`

I created two changes to overcome that: \n character added to each line and old (backed-up) crontab reinstallation in case of new crontab installation failure (which up to now resulted in no crontab at all and no backup of previous crontab).

I am rather a Python beginner, so if I am missing something, please let me know.

Cheers,
Lukasz